### PR TITLE
Update Tokio to 1.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,14 +20,14 @@ exclude = [
 [dependencies]
 blocking_xattr = { package = "xattr", version = "0.2.2" }
 
-tokio = { version = "0.2", features = ["blocking", "io-util"] }
+tokio = { version = "1", features = ["rt", "io-util"] }
 
 futures-core = "0.3"
 futures-util = "0.3"
 
 [dev-dependencies]
-tokio = { version = "0.2" }
-tokio-test = { version = "0.2" }
+tokio = { version = "1" }
+tokio-test = { version = "0.4" }
 
 rand = "0.7"
 tempfile = "3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,15 +20,14 @@ exclude = [
 [dependencies]
 blocking_xattr = { package = "xattr", version = "0.2.2" }
 
-tokio-io = { version = "=0.2.0-alpha.4", features = ["util"] }
-tokio-executor = { version = "=0.2.0-alpha.4", features = ["blocking"] }
+tokio = { version = "0.2", features = ["blocking", "io-util"] }
 
-futures-core-preview = "= 0.3.0-alpha.18"
-futures-util-preview = "= 0.3.0-alpha.18"
+futures-core = "0.3"
+futures-util = "0.3"
 
 [dev-dependencies]
-tokio = { version = "=0.2.0-alpha.4" }
-tokio-test = { version = "=0.2.0-alpha.4" }
+tokio = { version = "0.2" }
+tokio-test = { version = "0.2" }
 
 rand = "0.7"
 tempfile = "3"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,5 +22,5 @@ where
     F: FnOnce() -> io::Result<T> + Send + 'static,
     T: Send + 'static,
 {
-    tokio_executor::blocking::run(f).await
+    tokio::task::spawn_blocking(f).await?
 }


### PR DESCRIPTION
This is based on the 0.2 PR - I made them separately since 0.2 is still quite popular, and if desired you can release a major version that covers 0.2 as well as one that does 1.0